### PR TITLE
Link nos cabeçalhos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,8 @@
         "next-mdx-remote-client": "^2.1.3",
         "prettier": "3.6.2",
         "prettier-plugin-tailwindcss": "^0.6.14",
+        "rehype-autolink-headings": "^7.1.0",
+        "rehype-slug": "^6.0.0",
         "tailwindcss": "^4.1.11",
         "typescript": "^5.9.2",
         "typescript-eslint": "^8.39.0"
@@ -4082,6 +4084,13 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4231,6 +4240,34 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/hast-util-to-estree": {
@@ -7462,6 +7499,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/rehype-autolink-headings": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-7.1.0.tgz",
+      "integrity": "sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-recma": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
@@ -7471,6 +7527,24 @@
         "@types/estree": "^1.0.0",
         "@types/hast": "^3.0.0",
         "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "next-mdx-remote-client": "^2.1.3",
     "prettier": "3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.14",
+    "rehype-autolink-headings": "^7.1.0",
+    "rehype-slug": "^6.0.0",
     "tailwindcss": "^4.1.11",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.39.0"

--- a/src/app/blog/utils.ts
+++ b/src/app/blog/utils.ts
@@ -7,6 +7,8 @@ import {
 } from '@shikijs/transformers';
 import type { EvaluateOptions } from 'next-mdx-remote-client/rsc';
 import { serialize } from 'next-mdx-remote-client/serialize';
+import rehypeAutolinkHeadings from 'rehype-autolink-headings';
+import rehypeSlug from 'rehype-slug';
 import remarkGfm from 'remark-gfm';
 import { transformerCodeBlock } from '@/lib/shiki/transformer-code-block';
 import { transformerMetaDiff } from '@/lib/shiki/transformer-meta-diff';
@@ -52,6 +54,20 @@ export function serializeMDX(source: string) {
               transformerMetaHighlight(),
               transformerCodeBlock(),
             ],
+          },
+        ],
+        [rehypeSlug],
+        [
+          rehypeAutolinkHeadings,
+          {
+            behavior: 'wrap',
+            headingProperties: {
+              className: 'scroll-mt-6',
+            },
+            properties: {
+              target: '_self',
+              className: 'linked-heading no-underline',
+            },
           },
         ],
       ],

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -64,4 +64,11 @@
   span.shiki {
     @apply bg-transparent!;
   }
+
+  .prose :is(h1, h2, h3, h4, h5, h6) a:is(:hover, :focus, :active)::before,
+  .prose :is(h1, h2, h3, h4, h5, h6):is(:target, :focus) a::before {
+    content: '#';
+    transform: translate(-1em);
+    @apply absolute opacity-70 max-lg:hidden;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="pt-BR">
+    <html lang="pt-BR" className="scroll-smooth">
       <body className="bg-stone-950 antialiased">{children}</body>
     </html>
   );


### PR DESCRIPTION
Nesse PR estou adicionando um recurso que irá permitir compartilharmos links de cabeçalhos específicos. 

## Como funciona?

Esse mecanismo funciona adicionando uma âncora em todos os cabeçalhos do conteúdo do blog. Quando clicado, o browser irá fazer scroll de forma suave até o conteúdo clicado. Ao acessar o blog direto por um link, o scroll também acontecerá

## Mudanças visuais

A partir de agora, em dispositivos grandes, ao passar o mouse em cabeçalhos nos posts do blog, uma `#` será exibido na lateral esquerda. Em telas menores, esse caractere não será exibido.