### PR TITLE
Configurações de SEO dos posts

### DIFF
--- a/src/app/blog/[slug]/blog-content.tsx
+++ b/src/app/blog/[slug]/blog-content.tsx
@@ -24,7 +24,7 @@ export function BlogContent({ mdxSource, metadata, scope }: ContentProps) {
   const { title, summary, publishedAt } = metadata;
 
   return (
-    <main className="mx-auto grid grid-cols-[1fr_auto_1fr]">
+    <section className="mx-auto grid grid-cols-[1fr_auto_1fr]">
       <header className="col-start-2 col-end-3 mx-auto prose prose-xl px-4 py-12 prose-invert">
         <h1>{title}</h1>
         {summary && (
@@ -56,6 +56,6 @@ export function BlogContent({ mdxSource, metadata, scope }: ContentProps) {
       <aside className="col-start-3 row-start-2">
         <TableOfContents toc={scope.toc ?? []} />
       </aside>
-    </main>
+    </section>
   );
 }

--- a/src/app/blog/[slug]/blog-content.tsx
+++ b/src/app/blog/[slug]/blog-content.tsx
@@ -5,40 +5,36 @@ import { MDXClient } from 'next-mdx-remote-client';
 import type { SerializeResult } from 'next-mdx-remote-client/serialize';
 import { components } from '@/components/mdx';
 import { TableOfContents } from '@/components/table-of-contents';
-import { Frontmatter, Scope } from '../utils';
+import { Metadata, Scope } from '../utils';
 
 type ContentProps = {
-  mdxSource: SerializeResult<Frontmatter, Scope>;
+  mdxSource: SerializeResult<Metadata, Scope>;
+  slug: string;
+  metadata: Metadata;
+  scope: Scope;
 };
 
-export function BlogContent({ mdxSource }: ContentProps) {
+export function BlogContent({ mdxSource, metadata, scope }: ContentProps) {
   if ('error' in mdxSource) {
     throw new Error(mdxSource.error.message, {
       cause: mdxSource.error,
     });
   }
 
-  const { frontmatter, scope } = mdxSource;
+  const { title, summary, publishedAt } = metadata;
 
   return (
     <main className="mx-auto grid grid-cols-[1fr_auto_1fr]">
       <header className="col-start-2 col-end-3 mx-auto prose prose-xl px-4 py-12 prose-invert">
-        <h1>{frontmatter.title}</h1>
-        {frontmatter.summary && (
-          <p className="text-left text-lg text-gray-300">
-            {frontmatter.summary}
-          </p>
+        <h1>{title}</h1>
+        {summary && (
+          <p className="text-left text-lg text-gray-300">{summary}</p>
         )}
         <div className="flex flex-wrap gap-4 text-sm text-gray-400">
-          {frontmatter.publishedAt && (
-            <time
-              dateTime={frontmatter.publishedAt}
-              className="flex items-center gap-2"
-            >
+          {publishedAt && (
+            <time dateTime={publishedAt} className="flex items-center gap-2">
               <CalendarIcon className="size-4" />
-              <span>
-                {frontmatter.publishedAt.split('-').reverse().join('/')}
-              </span>
+              <span>{publishedAt.split('-').reverse().join('/')}</span>
             </time>
           )}
 
@@ -58,7 +54,7 @@ export function BlogContent({ mdxSource }: ContentProps) {
       </article>
 
       <aside className="col-start-3 row-start-2">
-        <TableOfContents toc={mdxSource.scope.toc ?? []} />
+        <TableOfContents toc={scope.toc ?? []} />
       </aside>
     </main>
   );

--- a/src/app/blog/[slug]/blog-content.tsx
+++ b/src/app/blog/[slug]/blog-content.tsx
@@ -5,6 +5,7 @@ import { MDXClient } from 'next-mdx-remote-client';
 import type { SerializeResult } from 'next-mdx-remote-client/serialize';
 import { components } from '@/components/mdx';
 import { TableOfContents } from '@/components/table-of-contents';
+import { baseUrl } from '@/lib/constants';
 import { Metadata, Scope } from '../utils';
 
 type ContentProps = {
@@ -14,7 +15,12 @@ type ContentProps = {
   scope: Scope;
 };
 
-export function BlogContent({ mdxSource, metadata, scope }: ContentProps) {
+export function BlogContent({
+  mdxSource,
+  metadata,
+  scope,
+  slug,
+}: ContentProps) {
   if ('error' in mdxSource) {
     throw new Error(mdxSource.error.message, {
       cause: mdxSource.error,
@@ -25,6 +31,26 @@ export function BlogContent({ mdxSource, metadata, scope }: ContentProps) {
 
   return (
     <section className="mx-auto grid grid-cols-[1fr_auto_1fr]">
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'BlogPosting',
+            headline: title,
+            datePublished: publishedAt,
+            dateModified: publishedAt,
+            description: summary,
+            image: `${baseUrl}/og?title=${encodeURIComponent(title)}`,
+            url: `${baseUrl}/blog/${slug}`,
+            author: {
+              '@type': 'Person',
+              name: 'Adriano de Azevedo',
+            },
+          }),
+        }}
+      />
       <header className="col-start-2 col-end-3 mx-auto prose prose-xl px-4 py-12 prose-invert">
         <h1>{title}</h1>
         {summary && (

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,4 +1,6 @@
+import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
+import { baseUrl, siteName } from '@/lib/constants';
 import { getBlogPosts } from '../utils';
 import { BlogContent } from './blog-content';
 
@@ -12,13 +14,60 @@ export async function generateStaticParams() {
   });
 }
 
-type BlogProps = {
+type Props = {
   params: Promise<{ slug: string }>;
 };
 
-export default async function Blog({ params }: BlogProps) {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
-  const post = (await getBlogPosts()).find((post) => post.slug === slug);
+
+  const post = (await getBlogPosts()).find((post) => {
+    return post.slug === slug;
+  });
+
+  if (!post) {
+    throw new Error('Post not found');
+  }
+
+  const {
+    title,
+    publishedAt: publishedTime,
+    summary: description,
+  } = post.metadata;
+
+  const ogImage = `${baseUrl}/og?title=${encodeURIComponent(title)}`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: 'article',
+      publishedTime,
+      url: `${baseUrl}/blog/${post.slug}`,
+      siteName,
+      images: [
+        {
+          url: ogImage,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [ogImage],
+    },
+  };
+}
+
+export default async function Blog({ params }: Props) {
+  const { slug } = await params;
+
+  const post = (await getBlogPosts()).find((post) => {
+    return post.slug === slug;
+  });
 
   if (!post) {
     notFound();

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import { getBlogPosts, serializeMDX } from '../utils';
+import { getBlogPosts } from '../utils';
 import { BlogContent } from './blog-content';
 
 export async function generateStaticParams() {
@@ -24,7 +24,5 @@ export default async function Blog({ params }: BlogProps) {
     notFound();
   }
 
-  const mdxSource = await serializeMDX(post.content);
-
-  return <BlogContent mdxSource={mdxSource} />;
+  return <BlogContent {...post} />;
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,18 @@
+import { getBlogPosts } from '@/app/blog/utils';
+import { baseUrl } from '@/lib/constants';
+
+export default async function sitemap() {
+  const blogs = (await getBlogPosts()).map((post) => {
+    return {
+      url: `${baseUrl}/blog/${post.slug}`,
+      lastModified: post.metadata.publishedAt,
+    };
+  });
+
+  const routes = [''].map((route) => ({
+    url: `${baseUrl}${route}`,
+    lastModified: new Date().toISOString().split('T')[0],
+  }));
+
+  return [...routes, ...blogs];
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,1 +1,3 @@
+export const siteName = 'oazevedo.dev';
+
 export const baseUrl = 'https://oazevedo.dev';

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const baseUrl = 'https://oazevedo.dev';


### PR DESCRIPTION
Configurações de SEO e metadados são importante para conseguirmos indexar o site em mecanismos de busca e melhorar a aparência de links compartilhados em redes sociais.

Nesse PR estou adicionando algumas configurações básicas de SEO:
- Sitemap: para listarmos todos os links de publicações que existem no site
- Metadata e JSON Schema para prover dados enriquecidos para uma melhor indexação das publicações